### PR TITLE
#2 switch to licence expression and set repo url

### DIFF
--- a/Source/ServiceLocation/ServiceLocation.csproj
+++ b/Source/ServiceLocation/ServiceLocation.csproj
@@ -13,8 +13,9 @@
     <PackageTags>CommonServiceLocator ServiceLocation Microsoft.Practices.ServiceLocation NetCore NetStandard</PackageTags>
     <PackageIconUrl>https://nuget.org/Media/Default/Packages/Unity/2.0/entlib_new_icon_100x100.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Chavoshi/CommonServiceLocator.NetCore</PackageProjectUrl>
-    <PackageLicenseUrl>http://opensource.org/licenses/Apache-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/Chavoshi/CommonServiceLocator.NetCore</RepositoryUrl>
     <AssemblyVersion>1.3.0.0</AssemblyVersion>
     <FileVersion>1.3.0.0</FileVersion>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
With this change the package will now have a more informative readme and have a direct link to the repo to enable sourcelink.

closes #2